### PR TITLE
typing.Callable 형의 인자에 callable하지 않은 값을 넣으면 죽는 문제 해결

### DIFF
--- a/tests/typed_test.py
+++ b/tests/typed_test.py
@@ -72,6 +72,8 @@ def check_callable(f: typing.Callable[[], str]) -> str:
 
 def test_callable():
     assert check_callable(_call)
+    with raises(TypeError):
+        check_callable('not callable')
 
 
 def _call2(x: str, y: int) -> bool:

--- a/tsukkomi/typed.py
+++ b/tsukkomi/typed.py
@@ -123,7 +123,7 @@ def check_union(data: typing.Union, hint: type) -> bool:
     :param hint: assumed type of given ``data``
 
     """
-    r = any(c for _, c in [check_type(data, t) for t in hint.__union_params__])
+    r = any(check_type(data, t)[1] for t in hint.__union_params__)
     if not r:
         raise TypeError(
             'expected one of {0!r}, found: {1!r}'.format(

--- a/tsukkomi/typed.py
+++ b/tsukkomi/typed.py
@@ -76,6 +76,8 @@ def check_callable(callable_: typing.Callable, hint: type) -> bool:
     :param hint: assumed type of given ``callable_``
 
     """
+    if not callable(callable_):
+        return type(callable_), False
     hints = typing.get_type_hints(callable_)
     return_type = hints.pop('return', type(None))
     signature = inspect.signature(callable_)


### PR DESCRIPTION
자세한 것은 추가된 테스트 케이스를 확인해보시면 됩니다.
