### PR TITLE
Consider classes are typing.Callable

### DIFF
--- a/tests/typed_test.py
+++ b/tests/typed_test.py
@@ -70,10 +70,24 @@ def check_callable(f: typing.Callable[[], str]) -> str:
     return f()
 
 
+class TestCls(object):
+
+    pass
+
+
+@typechecked
+def check_callable_cls(f: typing.Callable) -> str:
+    assert f()
+    return 'hello world'
+
+
 def test_callable():
     assert check_callable(_call)
     with raises(TypeError):
         check_callable('not callable')
+    with raises(TypeError):
+        check_callable(TestCls)
+    check_callable_cls(TestCls)
 
 
 def _call2(x: str, y: int) -> bool:

--- a/tsukkomi/typed.py
+++ b/tsukkomi/typed.py
@@ -78,6 +78,8 @@ def check_callable(callable_: typing.Callable, hint: type) -> bool:
     """
     if not callable(callable_):
         return type(callable_), False
+    if callable(callable_) and not hasattr(callable_, '__code__'):
+        return type(callable_), True
     hints = typing.get_type_hints(callable_)
     return_type = hints.pop('return', type(None))
     signature = inspect.signature(callable_)


### PR DESCRIPTION
it is possible object is callable since `callable()` return `True`
but it dosen't have `__code__` attribute. so `check_callable` consider
these objects are callable
