### PR TITLE
Support Python 3.3 and 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 python:
+- 3.3
+- 3.4
 - 3.5
 install:
 - pip install tox-travis

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 import ast
+import sys
+
 from setuptools import find_packages, setup
 
 
@@ -27,6 +29,12 @@ def get_version():
 install_requires = [
     'setuptools',
 ]
+below35_requires = [
+    'typing',
+]
+if 'bdist_wheel' not in sys.argv and sys.version_info < (3, 5):
+    install_requires.extend(below35_requires)
+
 tests_require = [
     'pytest >= 2.9.0',
     'import-order',
@@ -49,6 +57,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=install_requires,
     extras_require={
+        ":python_version<'3.5'": below35_requires,
         'tests': tests_require,
         'docs': docs_require,
     },

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py35
+envlist = py33, py34, py35
 minversion = 2.3.0
 
 [testenv]
 deps =
     .[tests]
 commands =
-    ./pre-commit
     py.test {posargs:-v --durations=5} tests
+    py35: ./pre-commit


### PR DESCRIPTION
Added `typing` as an optional dependency for below Python 3.5.
