### PR TITLE
Handle a callable hint without any filters.

### DIFF
--- a/tests/typed_test.py
+++ b/tests/typed_test.py
@@ -122,6 +122,21 @@ def test_callable_has_callable_argument():
     assert check_callable3(_call3)
 
 
+@typechecked
+def check_callable4(f: typing.Callable) -> str:
+    return 'o' if f(x) else 'x'
+
+
+@typechecked
+def check_callable5(f: typing.Callable[..., typing.Any]) -> str:
+    return 'o' if f(x) else 'x'
+
+
+def test_callable_without_any_filters():
+    assert check_callable4(lambda x: True) == 'o'
+    assert check_callable5(lambda x: False) == 'x'
+
+
 class Human(object):
 
     @typechecked

--- a/tsukkomi/typed.py
+++ b/tsukkomi/typed.py
@@ -87,7 +87,17 @@ def check_callable(callable_: typing.Callable, hint: type) -> bool:
         param.annotation
         for _, param in signature.parameters.items()
     )
-    correct = hint.__args__ == arg_types and hint.__result__ == return_type
+    correct = all({
+        any({
+            hint.__args__ is None,
+            hint.__args__ is Ellipsis,
+            hint.__args__ == arg_types,
+        }),
+        any({
+            hint.__result__ is None,
+            hint.__result__ in (typing.Any, return_type)
+        })
+    })
     return typing.Callable[list(arg_types), return_type], correct
 
 


### PR DESCRIPTION
This patch makes this library handle `typing.Callable`, `typing.Callable[..., typing.Any]` annotations.
