### PR TITLE
Proper error message from check_tuple()

### DIFF
--- a/tests/typed_test.py
+++ b/tests/typed_test.py
@@ -279,8 +279,15 @@ def check_tuple(a: typing.Tuple[int, int]) -> typing.Tuple[int, int]:
 
 def test_typing_tuple():
     assert check_tuple((1, 2))
-    with raises(TypeError):
-        assert check_tuple(1)
+    with raises(TypeError) as e:
+        check_tuple(1)
+    assert str(e.value) == 'expected typing.Tuple[int, int], not int: 1'
+    with raises(TypeError) as e:
+        check_tuple(None)
+    assert str(e.value) == 'expected typing.Tuple[int, int], not None'
+    with raises(TypeError) as e:
+        check_tuple(())
+    assert str(e.value) == 'expected tuple size is 2, not 0: ()'
 
 
 @typechecked

--- a/tsukkomi/typed.py
+++ b/tsukkomi/typed.py
@@ -5,7 +5,6 @@
 import functools
 import inspect
 import itertools
-import types
 import typing
 
 __all__ = (
@@ -107,7 +106,8 @@ def check_callable(callable_: typing.Callable, hint: type) -> bool:
     return typing.Callable[list(arg_types), return_type], correct
 
 
-def check_tuple(data: typing.Tuple, hint: type) -> bool:
+def check_tuple(data: typing.Tuple,
+                hint: typing.Union[type, typing.TypingMeta]) -> bool:
     """Check argument type & return type of :class:`typing.Tuple`. since it
     raises check :class:`typing.Tuple` using `isinstance`, so compare in
     diffrent way
@@ -116,10 +116,20 @@ def check_tuple(data: typing.Tuple, hint: type) -> bool:
     :param hint: assumed type of given ``data``
 
     """
+    if not isinstance(data, tuple):
+        raise TypeError(
+            'expected {}, not {}'.format(
+                typing._type_repr(hint),
+                'None' if data is None else '{}: {!r}'.format(
+                    typing._type_repr(type(data)),
+                    data
+                )
+            )
+        )
     tuple_param = hint.__tuple_params__
     if len(data) != len(tuple_param):
-        raise TypeError('expected tuple size is {},'
-                        'found: {}'.format(len(tuple_param), len(data)))
+        raise TypeError('expected tuple size is {}, not {}: '
+                        '{!r}'.format(len(tuple_param), len(data), data))
     zipped = itertools.zip_longest(data, tuple_param)
     for i, (v, t) in enumerate(zipped):
         _, correct = check_type(v, t)


### PR DESCRIPTION
Previously tsukkomi raises `TypeError` with useless error message when an expected type is `typing.Tuple[X, Y]` but the given value is not even `tuple`:
- `TypeError: object of type 'int' has no len()` if the given value is `1`
- `TypeError: object of type 'NoneType' has no len()` if the given value is `None`

It's because `check_tuple()` tries to get `len()` of the given value without ensuring if the given value is a tuple.  If the given value doesn't provide `__len__()` (e.g. `int`), it fails to count its element since it even is not a sequence!

So this patch makes `check_tuple()` to check whether the given value is even a `tuple`.  It additionally prevents to accept non-`tuple` sequences like `str`/`list` as well.

**Plus: we need to test all error messages of raises `TypeError` objects.  Testing only error types is not enough since Python could randomly raise `TypeError` even if it's tsukkomi's bug!**
